### PR TITLE
[🐸 Frogbot] Update Maven dependencies

### DIFF
--- a/jeecg-boot/pom.xml
+++ b/jeecg-boot/pom.xml
@@ -45,7 +45,7 @@
 		<commonmark.version>0.17.0</commonmark.version>
 		<knife4j-spring-boot-starter.version>4.4.0</knife4j-spring-boot-starter.version>
 		<!-- 数据库驱动 -->
-		<postgresql.version>42.2.25</postgresql.version>
+		<postgresql.version>42.3.3</postgresql.version>
 		<ojdbc6.version>11.2.0.3</ojdbc6.version>
 		<sqljdbc4.version>4.0</sqljdbc4.version>
 		<mysql-connector-java.version>8.0.27</mysql-connector-java.version>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![critical (not applicable)](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/notApplicableCritical.png)<br>Critical | CVE-2024-1597 | Not Applicable | org.postgresql:postgresql:42.2.25<br>org.jeecgframework.boot:jeecg-boot-base-core:3.7.2<br>org.jeecgframework.boot:jeecg-system-local-api:3.7.2<br>org.jeecgframework.boot:jeecg-module-demo:3.7.2 | org.postgresql:postgresql 42.2.25 | [42.2.28]<br>[42.3.9]<br>[42.4.4]<br>[42.5.5]<br>[42.6.1]<br>[42.7.2] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Jfrog Research Severity:** | <img src="https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/smallMedium.svg" alt=""/> Medium |
| **Contextual Analysis:** | Not Applicable |
| **Direct Dependencies:** | org.postgresql:postgresql:42.2.25, org.jeecgframework.boot:jeecg-boot-base-core:3.7.2, org.jeecgframework.boot:jeecg-system-local-api:3.7.2, org.jeecgframework.boot:jeecg-module-demo:3.7.2 |
| **Impacted Dependency:** | org.postgresql:postgresql:42.2.25 |
| **Fixed Versions:** | [42.2.28], [42.3.9], [42.4.4], [42.5.5], [42.6.1], [42.7.2] |
| **CVSS V3:** | 9.8 |

Improper escaping of numeric values in PostgreSQL JDBC Driver may lead to SQL injection when using a non-default query mode.

### 🔬 JFrog Research Details

**Description:**
[PostgreSQL](https://www.postgresql.org/) is a relational database management system (RDBMS) that uses and extends the SQL language combined with many features that safely store and scale the most complicated data workloads.

The [PostgreSQL JDBC Driver](https://jdbc.postgresql.org/) allows Java programs to connect to a PostgreSQL database using standard, database independent Java code.

There are different modes for executing queries on a database: `extended` (which is the default), `extendForPrepared`, `extendedCacheEverything` and `simple`.
In the `simple` mode, the frontend just sends a textual query string, which is parsed and immediately executed by the backend.

To be affected, the victim must use the non-default `simple` query mode when connecting to the database by adding it to the JDBC connection string, which is highly unlikely to be used.
An example of a connection string that uses this mode: `jdbc:postgresql://localhost:5432/?preferQueryMode=simple`.

Attackers can exploit the vulnerability to cause an unexpected behavior or to perform SQL Injection.

To perform unexpected behavior the affected code must have an SQL query that contains `-` (minus) and an attacker-controlled numeric variable. This is due to PostgreSQL treating these variables as literals and not escaping them.
For example: `SELECT -? FROM tablename`.
The attacker will need to insert a negative number (that starts with `-`), which will cause PostgreSQL to treat it as a comment (double-minus: `--`).
For example, a `-3` number will cause the query to be parsed as: `SELECT --3 FROM tablename`, which will cause unexpected behavior.

An SQL injection is also possible if a query like this includes an attacker-controlled string after the numeric variable as well and is on the same line.
For example: `SELECT -?, ? FROM tablename`.
When inserting a negative number, the attackers can insert a string that contains the SQL query they wish to execute.

To successfully trigger the vulnerability, all of the following conditions must be satisfied:
1. A Non-default query mode (`?preferQueryMode=simple` at the end of the the JDBC connection string), which is highly unlikely.
2. SQL query with two attacker-controlled variables (one numeric and one string in the same line). The string variable must be after the numeric one.
3. The SQL query must contain "-" before and adjacent to the numeric variable (for example, `SELECT -?, ? FROM tablename`)

**Remediation:**
##### Development mitigations

If your SQL query contains a minus (`-`) followed by a numeric variable that is user-controlled, verify the number is not a negative number before passing it to the prepared statement (for example, the `java.sql.PreparedStatement.setInt` function).
Alternatively, don't use the `preferQueryMode=simple` mode.



---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


[comment]: <> (Checksum: 095e745cb1631e72065d6c5162275969)
